### PR TITLE
Fix wrong case in trim method

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 const trim = (str) => {
-    const trimmed_string = str.trim();
-    return trimmed_string;
+    const trimmedString = str.trim();
+    return trimmedString;
 }
 
 module.exports = {


### PR DESCRIPTION
This pull request fixes the issue where the trim method in utils was in snake_case instead of pascalCase.

[This PR and the changes in it were generated by Jira-GPT (wip)]