### PR TITLE
Fix wrong case in trim method

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,14 @@
+The content of the "../../repositories/awesome-project/src/utils.js" file should be:
+
+```javascript
 const trim = (str) => {
-    const trimmed_string = str.trim();
-    return trimmed_string;
+    const trimmedString = str.trim();
+    return trimmedString;
 }
 
 module.exports = {
     trim
 }
+``` 
+
+with the `trim` method in pascalCase.


### PR DESCRIPTION
This pull request fixes the  method in  by changing it to pascalCase. The method was previously in snake_case.

[This PR and the changes in it were generated by Jira-GPT (wip)]